### PR TITLE
Introduce option compact for search output

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,6 +18,7 @@ program
   .command('search [term]')
   .description('Search for jobs on the Jenkins server')
   .option('-b, --building', 'show only jobs that are currently building')
+  .option('-c, --compact', 'show jobs in a single wrapping line')
   .action(require('./commands/search'));
 
 program

--- a/lib/commands/command.js
+++ b/lib/commands/command.js
@@ -68,6 +68,46 @@ function columns(collection) {
 }
 
 /**
+ * Output a collection in a wrapping line (ls without -l)
+ * @param {array[string]} list
+ * @param {string} tabwidth
+ */
+function compact(list, tabwidth) {
+  var i = 0;
+  var l = 0;
+  var maxWidth = 0;
+  var spaces = [];
+  var next = "";
+  var output = "";
+
+  if (!_.isArray(list)) {
+    list = [list];
+  }
+
+  // get largest item
+  for (var i = 0, l = list.length; i < l; i += 1) {
+    maxWidth = Math.max(maxWidth, list[i].length);
+  }
+  maxWidth += 1;
+  // build spaces
+  for (i = 0; i < maxWidth; i += 1) {
+    spaces.push(" ");
+  }
+  var currentLine = "";
+  // create output
+  for (i = 0, l = list.length; i < l; i += 1) {
+    if (process.stdout.columns < currentLine.length) {
+      // flush line
+      output += currentLine + "\n";
+      currentLine = "";
+    }
+    currentLine += list[i] + spaces.slice(0, (maxWidth - list[i].length)).join("");
+  }
+  output += currentLine;
+  console.log(output);
+}
+
+/**
  * Log to the console.
  */
 function log() {
@@ -109,5 +149,6 @@ module.exports = {
   log: log,
   success: success,
   info: info,
-  error: error
+  error: error,
+  compact: compact
 };

--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -3,6 +3,7 @@ var chalk = require('chalk');
 
 module.exports = function (term, options) {
   var showOnlyBuilding = options.building;
+  var displayAsColumns = options.compact !== true;
 
   var jenkins = command.api();
   jenkins.jobList(function (err, jobList) {
@@ -20,32 +21,60 @@ module.exports = function (term, options) {
         return job.name.indexOf(term) > -1;
       });
     }
-    jobs.map(function (job) {
-      delete job.url;
-      if (job.color.indexOf('anime') > -1) {
-        job.build_status = chalk.blue('BUILDING');
-      } else if (job.color === 'blue') {
-        job.build_status = chalk.green('SUCCESS');
-      } else if (job.color === 'red') {
-        job.build_status = chalk.red('FAILED');
-      } else if (job.color === 'yellow') {
-        job.build_status = chalk.yellow('UNSTABLE');
-      } else if (job.color === 'disabled') {
-        job.build_status = chalk.gray('DISABLED');
-      } else if (job.color === 'aborted') {
-        job.build_status = chalk.gray.strikethrough('ABORTED');
+    if (displayAsColumns) {
+      if (term) {
+        command.log('\nSearch for \'' + term + '\' gave ' + jobs.length + ' results:\n');
       } else {
-        job.build_status = job.color.toUpperCase();
+        command.log('\nSearch gave ' + jobs.length + ' results:\n');
       }
-      delete job.color;
-    });
-
-    if (term) {
-      command.log('\nSearch for \'' + term + '\' gave ' + jobs.length + ' results:\n');
+      printAsColumns(command, jobs);
     } else {
-      command.log('\nSearch gave ' + jobs.length + ' results:\n');
+      printAsRow(command, jobs);
     }
-    command.columns(jobs);
-
   });
 };
+
+
+function printAsRow(command, jobs) {
+  jobs = jobs.map(function (job) {
+    if (job.color.indexOf('anime') > -1) {
+      return chalk.blue(job.name);
+    } else if (job.color === 'blue') {
+      return chalk.green(job.name);
+    } else if (job.color === 'red') {
+      return chalk.red(job.name);
+    } else if (job.color === 'yellow') {
+      return chalk.yellow(job.name);
+    } else if (job.color === 'disabled') {
+      return chalk.gray(job.name);
+    } else if (job.color === 'aborted') {
+      return chalk.gray.strikethrough(job.name);
+    }
+    return chalk.white(job.name);
+  });
+  command.compact(jobs);
+}
+
+
+function printAsColumns(command, jobs) {
+  jobs.map(function (job) {
+    delete job.url;
+    if (job.color.indexOf('anime') > -1) {
+      job.build_status = chalk.blue('BUILDING');
+    } else if (job.color === 'blue') {
+      job.build_status = chalk.green('SUCCESS');
+    } else if (job.color === 'red') {
+      job.build_status = chalk.red('FAILED');
+    } else if (job.color === 'yellow') {
+      job.build_status = chalk.yellow('UNSTABLE');
+    } else if (job.color === 'disabled') {
+      job.build_status = chalk.gray('DISABLED');
+    } else if (job.color === 'aborted') {
+      job.build_status = chalk.gray.strikethrough('ABORTED');
+    } else {
+      job.build_status = job.color.toUpperCase();
+    }
+    delete job.color;
+  });
+  command.columns(jobs);
+}


### PR DESCRIPTION
Hi again.

At work we have loads of jobs. Thus, the current columns display is getting too long. This PR adds an option `-c` or `--compact` to print the jobs like a `ls`.

Thanks.
sagold